### PR TITLE
Option to skip code backup

### DIFF
--- a/train_val_cls.py
+++ b/train_val_cls.py
@@ -27,6 +27,7 @@ def main():
     parser.add_argument('--save_folder', '-s', help='Path to folder for saving check points and summary', required=True)
     parser.add_argument('--model', '-m', help='Model to use', required=True)
     parser.add_argument('--setting', '-x', help='Setting to use', required=True)
+    parser.add_argument('--no_code_backup', help='Dont backup code', action='store_true')
     args = parser.parse_args()
 
     time_string = datetime.now().strftime('%Y-%m-%d-%H-%M-%S')
@@ -206,8 +207,9 @@ def main():
     saver = tf.train.Saver(max_to_keep=None)
 
     # backup all code
-    code_folder = os.path.abspath(os.path.dirname(__file__))
-    shutil.copytree(code_folder, os.path.join(root_folder, os.path.basename(code_folder)))
+    if not args.no_code_backup:
+        code_folder = os.path.abspath(os.path.dirname(__file__))
+        shutil.copytree(code_folder, os.path.join(root_folder, os.path.basename(code_folder)))
 
     folder_ckpt = os.path.join(root_folder, 'ckpts')
     if not os.path.exists(folder_ckpt):


### PR DESCRIPTION
The use of shutil.copytree copies everything to the save folder
including shared objects and pyc files. This option is an opt-out for
cases where source code backup isn't needed.