### PR TITLE
Include creation of train_val_files.txt in prepare_partseg_data

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,6 @@ Here we list the commands for training/evaluating PointCNN on classification and
   cd data_conversions
   python3 ./download_datasets.py -d shapenet_partseg
   python3 ./prepare_partseg_data.py -f ../../data/shapenet_partseg
-  cat ../../data/shapenet_partseg/train_files.txt ../../data/shapenet_partseg/val_files.txt > ../../data/shapenet_partseg/train_val_files.txt
   cd ../pointcnn_seg
   ./train_val_shapenet.sh -g 0 -x shapenet_x8_2048_fps
   ./test_shapenet.sh -g 0 -x shapenet_x8_2048_fps -l ../../models/seg/pointcnn_seg_shapenet_x8_2048_fps_xxxx/ckpts/iter-xxxxx -r 10
@@ -190,16 +189,16 @@ Here we list the commands for training/evaluating PointCNN on classification and
   cd ../evaluation
   python3 semantic3d_merge.py -d <path to *_pred.h5> -v <reduced or full>
   ```
-  
+
 * ### Tensorboard
   If you want to moniter your train step, we recommand you use following command
   ```
   cd <your path>/PointCNN
   tensorboard --logdir=../models/<seg/cls> <--port=6006>
   ```
-  
-  
+
+
   ## More PointCNN Implementations
   * <a href="https://github.com/chinakook/PointCNN.MX" target="_blank">MXNet implementation</a>
-  
+
   * <a href="https://github.com/hxdengBerkeley/PointCNN.Pytorch" target="_blank">Pytorch implementation</a>

--- a/data_conversions/prepare_partseg_data.py
+++ b/data_conversions/prepare_partseg_data.py
@@ -129,6 +129,11 @@ def main():
                         idx_h5 = idx_h5 + 1
                     idx = idx + 1
 
+    train_val_txt = os.path.join(root, "train_val_files.txt")
+    with open(train_val_txt, "w") as train_val:
+        for part in ("train", "val"):
+            part_txt = os.path.join(root, "%s_files.txt" % part)
+            train_val.write(open(part_txt, "r").read())
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This change moves the concatenation of the train and val files to train_val_files.txt into the prepare script and out of the README. The intent is to simplify the burden on the user for preparing shapenet data.