### PR TITLE
Download and extract validation data to val directory directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,6 @@ Here we list the commands for training/evaluating PointCNN on classification and
   cd data_conversions
   bash download_semantic3d.sh
   bash un7z_semantic3d.sh
-  mkdir ../../data/semantic3d/val
-  mv ../../data/semantic3d/train/bildstein_station3_xyz_intensity_rgb.* ../../data/semantic3d/train/domfountain_station2_xyz_intensity_rgb.* ../../data/semantic3d/train/sg27_station4_intensity_rgb.* ../../data/semantic3d/train/untermaederbrunnen_station3_xyz_intensity_rgb.* ../../data/semantic3d/val
   python3 prepare_semantic3d_data.py
   mkdir ../../data/semantic3d/filelists
   python3 prepare_semantic3d_filelists.py

--- a/data_conversions/download_semantic3d.sh
+++ b/data_conversions/download_semantic3d.sh
@@ -1,32 +1,39 @@
 #!/usr/bin/env bash
-wget -c -N http://semantic3d.net/data/point-clouds/training1/bildstein_station1_xyz_intensity_rgb.7z -P ../../data/semantic3d/train/ | tr -d '\r'
-wget -c -N http://semantic3d.net/data/point-clouds/training1/bildstein_station3_xyz_intensity_rgb.7z -P ../../data/semantic3d/train/ | tr -d '\r'
-wget -c -N http://semantic3d.net/data/point-clouds/training1/bildstein_station5_xyz_intensity_rgb.7z -P ../../data/semantic3d/train/ | tr -d '\r'
-wget -c -N http://semantic3d.net/data/point-clouds/training1/domfountain_station1_xyz_intensity_rgb.7z -P ../../data/semantic3d/train/ | tr -d '\r'
-wget -c -N http://semantic3d.net/data/point-clouds/training1/domfountain_station2_xyz_intensity_rgb.7z -P ../../data/semantic3d/train/ | tr -d '\r'
-wget -c -N http://semantic3d.net/data/point-clouds/training1/domfountain_station3_xyz_intensity_rgb.7z -P ../../data/semantic3d/train/ | tr -d '\r'
-wget -c -N http://semantic3d.net/data/point-clouds/training1/neugasse_station1_xyz_intensity_rgb.7z -P ../../data/semantic3d/train/ | tr -d '\r'
-wget -c -N http://semantic3d.net/data/point-clouds/training1/sg27_station1_intensity_rgb.7z -P ../../data/semantic3d/train/ | tr -d '\r'
-wget -c -N http://semantic3d.net/data/point-clouds/training1/sg27_station2_intensity_rgb.7z -P ../../data/semantic3d/train/ | tr -d '\r'
-wget -c -N http://semantic3d.net/data/point-clouds/training1/sg27_station4_intensity_rgb.7z -P ../../data/semantic3d/train/ | tr -d '\r'
-wget -c -N http://semantic3d.net/data/point-clouds/training1/sg27_station5_intensity_rgb.7z -P ../../data/semantic3d/train/ | tr -d '\r'
-wget -c -N http://semantic3d.net/data/point-clouds/training1/sg27_station9_intensity_rgb.7z -P ../../data/semantic3d/train/ | tr -d '\r'
-wget -c -N http://semantic3d.net/data/point-clouds/training1/sg28_station4_intensity_rgb.7z -P ../../data/semantic3d/train/ | tr -d '\r'
-wget -c -N http://semantic3d.net/data/point-clouds/training1/untermaederbrunnen_station1_xyz_intensity_rgb.7z -P ../../data/semantic3d/train/ | tr -d '\r'
-wget -c -N http://semantic3d.net/data/point-clouds/training1/untermaederbrunnen_station3_xyz_intensity_rgb.7z -P ../../data/semantic3d/train/ | tr -d '\r'
-wget -c -N http://semantic3d.net/data/sem8_labels_training.7z -P ../../data/semantic3d/train/ | tr -d '\r'
-wget -c -N http://semantic3d.net/data/point-clouds/testing1/birdfountain_station1_xyz_intensity_rgb.7z -P ../../data/semantic3d/test/ | tr -d '\r'
-wget -c -N http://semantic3d.net/data/point-clouds/testing1/castleblatten_station1_intensity_rgb.7z -P ../../data/semantic3d/test/ | tr -d '\r'
-wget -c -N http://semantic3d.net/data/point-clouds/testing1/castleblatten_station5_xyz_intensity_rgb.7z -P ../../data/semantic3d/test/ | tr -d '\r'
-wget -c -N http://semantic3d.net/data/point-clouds/testing1/marketplacefeldkirch_station1_intensity_rgb.7z -P ../../data/semantic3d/test/ | tr -d '\r'
-wget -c -N http://semantic3d.net/data/point-clouds/testing1/marketplacefeldkirch_station4_intensity_rgb.7z -P ../../data/semantic3d/test/ | tr -d '\r'
-wget -c -N http://semantic3d.net/data/point-clouds/testing1/marketplacefeldkirch_station7_intensity_rgb.7z -P ../../data/semantic3d/test/ | tr -d '\r'
-wget -c -N http://semantic3d.net/data/point-clouds/testing1/sg27_station10_intensity_rgb.7z -P ../../data/semantic3d/test/ | tr -d '\r'
-wget -c -N http://semantic3d.net/data/point-clouds/testing1/sg27_station3_intensity_rgb.7z -P ../../data/semantic3d/test/ | tr -d '\r'
-wget -c -N http://semantic3d.net/data/point-clouds/testing1/sg27_station6_intensity_rgb.7z -P ../../data/semantic3d/test/ | tr -d '\r'
-wget -c -N http://semantic3d.net/data/point-clouds/testing1/sg27_station8_intensity_rgb.7z -P ../../data/semantic3d/test/ | tr -d '\r'
-wget -c -N http://semantic3d.net/data/point-clouds/testing1/sg28_station2_intensity_rgb.7z -P ../../data/semantic3d/test/ | tr -d '\r'
-wget -c -N http://semantic3d.net/data/point-clouds/testing1/sg28_station5_xyz_intensity_rgb.7z -P ../../data/semantic3d/test/ | tr -d '\r'
-wget -c -N http://semantic3d.net/data/point-clouds/testing1/stgallencathedral_station1_intensity_rgb.7z -P ../../data/semantic3d/test/ | tr -d '\r'
-wget -c -N http://semantic3d.net/data/point-clouds/testing1/stgallencathedral_station3_intensity_rgb.7z -P ../../data/semantic3d/test/ | tr -d '\r'
-wget -c -N http://semantic3d.net/data/point-clouds/testing1/stgallencathedral_station6_intensity_rgb.7z -P ../../data/semantic3d/test/ | tr -d '\r'
+BASE_DIR=${1-../../data/semantic3d}
+
+# Training data
+wget -c -N http://semantic3d.net/data/point-clouds/training1/bildstein_station1_xyz_intensity_rgb.7z -P $BASE_DIR/train/
+wget -c -N http://semantic3d.net/data/point-clouds/training1/bildstein_station5_xyz_intensity_rgb.7z -P $BASE_DIR/train/
+wget -c -N http://semantic3d.net/data/point-clouds/training1/domfountain_station1_xyz_intensity_rgb.7z -P $BASE_DIR/train/
+wget -c -N http://semantic3d.net/data/point-clouds/training1/domfountain_station3_xyz_intensity_rgb.7z -P $BASE_DIR/train/
+wget -c -N http://semantic3d.net/data/point-clouds/training1/neugasse_station1_xyz_intensity_rgb.7z -P $BASE_DIR/train/
+wget -c -N http://semantic3d.net/data/point-clouds/training1/sg27_station1_intensity_rgb.7z -P $BASE_DIR/train/
+wget -c -N http://semantic3d.net/data/point-clouds/training1/sg27_station2_intensity_rgb.7z -P $BASE_DIR/train/
+wget -c -N http://semantic3d.net/data/point-clouds/training1/sg27_station5_intensity_rgb.7z -P $BASE_DIR/train/
+wget -c -N http://semantic3d.net/data/point-clouds/training1/sg27_station9_intensity_rgb.7z -P $BASE_DIR/train/
+wget -c -N http://semantic3d.net/data/point-clouds/training1/sg28_station4_intensity_rgb.7z -P $BASE_DIR/train/
+wget -c -N http://semantic3d.net/data/point-clouds/training1/untermaederbrunnen_station1_xyz_intensity_rgb.7z -P $BASE_DIR/train/
+wget -c -N http://semantic3d.net/data/sem8_labels_training.7z -P $BASE_DIR/train/
+
+# Validation data
+wget -c -N http://semantic3d.net/data/point-clouds/training1/bildstein_station3_xyz_intensity_rgb.7z -P $BASE_DIR/val/
+wget -c -N http://semantic3d.net/data/point-clouds/training1/domfountain_station2_xyz_intensity_rgb.7z -P $BASE_DIR/val/
+wget -c -N http://semantic3d.net/data/point-clouds/training1/sg27_station4_intensity_rgb.7z -P $BASE_DIR/val/
+wget -c -N http://semantic3d.net/data/point-clouds/training1/untermaederbrunnen_station3_xyz_intensity_rgb.7z -P $BASE_DIR/val/
+
+# Test data
+wget -c -N http://semantic3d.net/data/point-clouds/testing1/birdfountain_station1_xyz_intensity_rgb.7z -P $BASE_DIR/test/
+wget -c -N http://semantic3d.net/data/point-clouds/testing1/castleblatten_station1_intensity_rgb.7z -P $BASE_DIR/test/
+wget -c -N http://semantic3d.net/data/point-clouds/testing1/castleblatten_station5_xyz_intensity_rgb.7z -P $BASE_DIR/test/
+wget -c -N http://semantic3d.net/data/point-clouds/testing1/marketplacefeldkirch_station1_intensity_rgb.7z -P $BASE_DIR/test/
+wget -c -N http://semantic3d.net/data/point-clouds/testing1/marketplacefeldkirch_station4_intensity_rgb.7z -P $BASE_DIR/test/
+wget -c -N http://semantic3d.net/data/point-clouds/testing1/marketplacefeldkirch_station7_intensity_rgb.7z -P $BASE_DIR/test/
+wget -c -N http://semantic3d.net/data/point-clouds/testing1/sg27_station10_intensity_rgb.7z -P $BASE_DIR/test/
+wget -c -N http://semantic3d.net/data/point-clouds/testing1/sg27_station3_intensity_rgb.7z -P $BASE_DIR/test/
+wget -c -N http://semantic3d.net/data/point-clouds/testing1/sg27_station6_intensity_rgb.7z -P $BASE_DIR/test/
+wget -c -N http://semantic3d.net/data/point-clouds/testing1/sg27_station8_intensity_rgb.7z -P $BASE_DIR/test/
+wget -c -N http://semantic3d.net/data/point-clouds/testing1/sg28_station2_intensity_rgb.7z -P $BASE_DIR/test/
+wget -c -N http://semantic3d.net/data/point-clouds/testing1/sg28_station5_xyz_intensity_rgb.7z -P $BASE_DIR/test/
+wget -c -N http://semantic3d.net/data/point-clouds/testing1/stgallencathedral_station1_intensity_rgb.7z -P $BASE_DIR/test/
+wget -c -N http://semantic3d.net/data/point-clouds/testing1/stgallencathedral_station3_intensity_rgb.7z -P $BASE_DIR/test/
+wget -c -N http://semantic3d.net/data/point-clouds/testing1/stgallencathedral_station6_intensity_rgb.7z -P $BASE_DIR/test/

--- a/data_conversions/un7z_semantic3d.sh
+++ b/data_conversions/un7z_semantic3d.sh
@@ -1,32 +1,52 @@
-#!/usr/bin/env bash
-7z x ../../data/semantic3d/train/bildstein_station1_xyz_intensity_rgb.7z -o../../data/semantic3d/train | tr -d '\r'
-7z x ../../data/semantic3d/train/bildstein_station3_xyz_intensity_rgb.7z -o../../data/semantic3d/train | tr -d '\r'
-7z x ../../data/semantic3d/train/bildstein_station5_xyz_intensity_rgb.7z -o../../data/semantic3d/train | tr -d '\r'
-7z x ../../data/semantic3d/train/domfountain_station1_xyz_intensity_rgb.7z -o../../data/semantic3d/train | tr -d '\r'
-7z x ../../data/semantic3d/train/domfountain_station2_xyz_intensity_rgb.7z -o../../data/semantic3d/train | tr -d '\r'
-7z x ../../data/semantic3d/train/domfountain_station3_xyz_intensity_rgb.7z -o../../data/semantic3d/train | tr -d '\r'
-7z x ../../data/semantic3d/train/neugasse_station1_xyz_intensity_rgb.7z -o../../data/semantic3d/train | tr -d '\r'
-7z x ../../data/semantic3d/train/sem8_labels_training.7z -o../../data/semantic3d/train | tr -d '\r'
-7z x ../../data/semantic3d/train/sg27_station1_intensity_rgb.7z -o../../data/semantic3d/train | tr -d '\r'
-7z x ../../data/semantic3d/train/sg27_station2_intensity_rgb.7z -o../../data/semantic3d/train | tr -d '\r'
-7z x ../../data/semantic3d/train/sg27_station4_intensity_rgb.7z -o../../data/semantic3d/train | tr -d '\r'
-7z x ../../data/semantic3d/train/sg27_station5_intensity_rgb.7z -o../../data/semantic3d/train | tr -d '\r'
-7z x ../../data/semantic3d/train/sg27_station9_intensity_rgb.7z -o../../data/semantic3d/train | tr -d '\r'
-7z x ../../data/semantic3d/train/sg28_station4_intensity_rgb.7z -o../../data/semantic3d/train | tr -d '\r'
-7z x ../../data/semantic3d/train/untermaederbrunnen_station1_xyz_intensity_rgb.7z -o../../data/semantic3d/train | tr -d '\r'
-7z x ../../data/semantic3d/train/untermaederbrunnen_station3_xyz_intensity_rgb.7z -o../../data/semantic3d/train | tr -d '\r'
-7z x ../../data/semantic3d/test/birdfountain_station1_xyz_intensity_rgb.7z -o../../data/semantic3d/test | tr -d '\r'
-7z x ../../data/semantic3d/test/castleblatten_station1_intensity_rgb.7z -o../../data/semantic3d/test | tr -d '\r'
-7z x ../../data/semantic3d/test/castleblatten_station5_xyz_intensity_rgb.7z -o../../data/semantic3d/test | tr -d '\r'
-7z x ../../data/semantic3d/test/marketplacefeldkirch_station1_intensity_rgb.7z -o../../data/semantic3d/test | tr -d '\r'
-7z x ../../data/semantic3d/test/marketplacefeldkirch_station4_intensity_rgb.7z -o../../data/semantic3d/test | tr -d '\r'
-7z x ../../data/semantic3d/test/marketplacefeldkirch_station7_intensity_rgb.7z -o../../data/semantic3d/test | tr -d '\r'
-7z x ../../data/semantic3d/test/sg27_station10_intensity_rgb.7z -o../../data/semantic3d/test | tr -d '\r'
-7z x ../../data/semantic3d/test/sg27_station3_intensity_rgb.7z -o../../data/semantic3d/test | tr -d '\r'
-7z x ../../data/semantic3d/test/sg27_station6_intensity_rgb.7z -o../../data/semantic3d/test | tr -d '\r'
-7z x ../../data/semantic3d/test/sg27_station8_intensity_rgb.7z -o../../data/semantic3d/test | tr -d '\r'
-7z x ../../data/semantic3d/test/sg28_station2_intensity_rgb.7z -o../../data/semantic3d/test | tr -d '\r'
-7z x ../../data/semantic3d/test/sg28_station5_xyz_intensity_rgb.7z -o../../data/semantic3d/test | tr -d '\r'
-7z x ../../data/semantic3d/test/stgallencathedral_station1_intensity_rgb.7z -o../../data/semantic3d/test | tr -d '\r'
-7z x ../../data/semantic3d/test/stgallencathedral_station3_intensity_rgb.7z -o../../data/semantic3d/test | tr -d '\r'
-7z x ../../data/semantic3d/test/stgallencathedral_station6_intensity_rgb.7z -o../../data/semantic3d/test | tr -d '\r'
+#!/usr/bin/env bash -e
+BASE_DIR=${1-../../data/semantic3d}
+
+# Helper function to skip unpacking if already unpacked. Uses markers
+# to indicate when a file is successfully unpacked.
+unpack() {
+    local path=${1}
+    local marker=$path.unpacked
+    if [ -e $marker ]; then
+        echo "$path already unpacked, skipping"
+        return
+    fi
+    7z x $path -o$(dirname $path) -y
+    touch $marker
+}
+
+# Training data
+unpack $BASE_DIR/train/bildstein_station1_xyz_intensity_rgb.7z
+unpack $BASE_DIR/train/bildstein_station5_xyz_intensity_rgb.7z
+unpack $BASE_DIR/train/domfountain_station1_xyz_intensity_rgb.7z
+unpack $BASE_DIR/train/domfountain_station3_xyz_intensity_rgb.7z
+unpack $BASE_DIR/train/neugasse_station1_xyz_intensity_rgb.7z
+unpack $BASE_DIR/train/sg27_station1_intensity_rgb.7z
+unpack $BASE_DIR/train/sg27_station2_intensity_rgb.7z
+unpack $BASE_DIR/train/sg27_station5_intensity_rgb.7z
+unpack $BASE_DIR/train/sg27_station9_intensity_rgb.7z
+unpack $BASE_DIR/train/sg28_station4_intensity_rgb.7z
+unpack $BASE_DIR/train/untermaederbrunnen_station1_xyz_intensity_rgb.7z
+unpack $BASE_DIR/train/sem8_labels_training.7z
+
+# Validation data
+unpack $BASE_DIR/val/bildstein_station3_xyz_intensity_rgb.7z
+unpack $BASE_DIR/val/domfountain_station2_xyz_intensity_rgb.7z
+unpack $BASE_DIR/val/sg27_station4_intensity_rgb.7z
+unpack $BASE_DIR/val/untermaederbrunnen_station3_xyz_intensity_rgb.7z
+
+# Testing data
+unpack $BASE_DIR/test/birdfountain_station1_xyz_intensity_rgb.7z
+unpack $BASE_DIR/test/castleblatten_station1_intensity_rgb.7z
+unpack $BASE_DIR/test/castleblatten_station5_xyz_intensity_rgb.7z
+unpack $BASE_DIR/test/marketplacefeldkirch_station1_intensity_rgb.7z
+unpack $BASE_DIR/test/marketplacefeldkirch_station4_intensity_rgb.7z
+unpack $BASE_DIR/test/marketplacefeldkirch_station7_intensity_rgb.7z
+unpack $BASE_DIR/test/sg27_station10_intensity_rgb.7z
+unpack $BASE_DIR/test/sg27_station3_intensity_rgb.7z
+unpack $BASE_DIR/test/sg27_station6_intensity_rgb.7z
+unpack $BASE_DIR/test/sg27_station8_intensity_rgb.7z
+unpack $BASE_DIR/test/sg28_station2_intensity_rgb.7z
+unpack $BASE_DIR/test/sg28_station5_xyz_intensity_rgb.7z
+unpack $BASE_DIR/test/stgallencathedral_station1_intensity_rgb.7z
+unpack $BASE_DIR/test/stgallencathedral_station3_intensity_rgb.7z
+unpack $BASE_DIR/test/stgallencathedral_station6_intensity_rgb.7z


### PR DESCRIPTION
Rather than download and extract to train and then manually move to val (instructions in README.md) this change downloads and extracts the validation files to the val directory straight away.