### PR TITLE
Fix shebang in 'un7z_semantic3d.sh' script

### DIFF
--- a/data_conversions/un7z_semantic3d.sh
+++ b/data_conversions/un7z_semantic3d.sh
@@ -1,4 +1,7 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
+
+set -e
+
 BASE_DIR=${1-../../data/semantic3d}
 
 # Helper function to skip unpacking if already unpacked. Uses markers


### PR DESCRIPTION
- When invoked explicitly the error will be `‘bash -e’: No such file or directory`
- When invoked as `bash *.sh` the `-e` will be ignored

Use `set -e` to fix both cases